### PR TITLE
fix: SDK ES modules support and API key authentication (v1.0.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msgcore/sdk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Official TypeScript SDK for MsgCore universal messaging gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -53,8 +53,8 @@ import {
   WebhookDeliveryListResponse,
   WebhookDetailResponse,
   WebhookResponse
-} from './types';
-import { MsgCoreError, AuthenticationError, RateLimitError } from './errors';
+} from './types.js';
+import { MsgCoreError, AuthenticationError, RateLimitError } from './errors.js';
 
 class ApikeysAPI {
   constructor(private client: AxiosInstance, private msgcore: MsgCore) {}
@@ -468,7 +468,12 @@ export class MsgCore {
       this.client.interceptors.request.use((axiosConfig) => {
         const token = config.getToken!();
         if (token) {
-          axiosConfig.headers.Authorization = `Bearer ${token}`;
+          // Detect API keys (start with msc_) and use correct header
+          if (token.startsWith('msc_')) {
+            axiosConfig.headers['X-API-Key'] = token;
+          } else {
+            axiosConfig.headers.Authorization = `Bearer ${token}`;
+          }
         }
         return axiosConfig;
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 // Generated main export for MsgCore SDK
 // DO NOT EDIT - This file is auto-generated from backend contracts
 
-export { MsgCore } from './client';
-export * from './types';
-export * from './errors';
+export { MsgCore } from './client.js';
+export * from './types.js';
+export * from './errors.js';
 
 // Version info
-export const SDK_VERSION = '1.0.4';
-export const GENERATED_AT = '2025-10-28T18:58:02.670Z';
+export const SDK_VERSION = '1.0.5';
+export const GENERATED_AT = '2025-10-28T19:12:07.461Z';
 export const CONTRACTS_COUNT = 59;


### PR DESCRIPTION
# SDK Update v1.0.5

This release fixes critical ES modules compatibility and API key authentication issues in the MsgCore SDK.

**Version**: 1.0.5  
**Source**: [MsgCore Backend](https://github.com/msgcore/msgcore)

## Changes

### 🔧 ES Modules Support
- **Fixed import extensions**: Updated all internal imports from  to  extensions in  and 
- **Resolves module resolution issues**: Ensures proper ES module compatibility when published to npm

### 🔑 API Key Authentication Fix
- **Added API key detection**: SDK now properly detects MsgCore API keys (tokens starting with )
- **Correct header usage**: API keys use  header, JWT tokens use  header
- **Fixed authentication flow**: Resolves authentication issues for users with API keys

### 📦 Package Updates
- Version bump from 1.0.4 to 1.0.5
- Updated SDK metadata and generation timestamp
- Contract count: 59 endpoints

## Breaking Changes

None. This is a backward-compatible bug fix release.

## Migration Guide

No migration required. Existing code will continue to work with improved functionality:

- **JWT users**: No changes needed, continues using  header
- **API key users**: Authentication now works correctly with  header

Update your dependency:


